### PR TITLE
Change url from 'punkave' to 'apostrophecms' just wanted the GIF to work on NPMjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/punkave/apostrophe-palette.git"
+    "url": "git+https://github.com/apostrophecms/apostrophe-palette.git"
   },
   "keywords": [
     "ApostropheCMS",
@@ -17,9 +17,9 @@
   "author": "P'unk Ave",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/punkave/apostrophe-palette/issues"
+    "url": "https://github.com/apostrophecms/apostrophe-palette/issues"
   },
-  "homepage": "https://github.com/punkave/apostrophe-palette#readme",
+  "homepage": "https://github.com/apostrophecms/apostrophe-palette#readme",
   "devDependencies": {
     "eslint": "^4.2.0",
     "eslint-config-punkave": "^1.0.8",


### PR DESCRIPTION
GIF broke on NPMJS that makes me frustrated on not able to see the GIF. Fixed the url in package.json 😄 👍 