### PR TITLE
Added missing close curly brace

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ modules: {
         valueTemplate: '0 0 7px 2px %VALUE%'
       }
     ]
+  }
 }
 ```
 


### PR DESCRIPTION
A closing curly brace was missing in the readme (closing the 'apostrophe-palette-global' object). This adds it.