### PR TITLE
Use LESS files to build CSS

### DIFF
--- a/lib/modules/apostrophe-palette-global/index.js
+++ b/lib/modules/apostrophe-palette-global/index.js
@@ -1,4 +1,7 @@
 var _ = require('lodash');
+var fs = require('fs');
+var path = require('path');
+var less = require('less');
 
 module.exports = {
   improve: 'apostrophe-global',
@@ -11,7 +14,7 @@ module.exports = {
     var arrangedPaletteFields = [];
     if (options.arrangePaletteFields) {
 
-      options.arrangePaletteFields.forEach(function(item) {
+      options.arrangePaletteFields.forEach(function (item) {
         var temp;
         if (_.isString(item)) {
 
@@ -23,7 +26,7 @@ module.exports = {
               name: field.name,
               label: field.label,
               type: 'field',
-              schema: [ field ]
+              schema: [field]
             };
 
             arrangedPaletteFields.push(temp);
@@ -40,11 +43,12 @@ module.exports = {
             schema: []
           };
 
-          item.fields.forEach(function(field) {
+          item.fields.forEach(function (field) {
             var pField = _.find(options.paletteFields, { name: field });
             if (pField) {
               temp.schema.push(pField);
             } else {
+              console.log(123, field);
               self.apos.utils.warn('Unrecognized field in arrangePaletteFields: ' + field);
             }
           });
@@ -90,10 +94,9 @@ module.exports = {
     } else {
       options.arrangedPaletteFields = options.paletteFields;
     }
-
   },
 
-  construct: function(self, options) {
+  construct: function (self, options) {
 
     // This extra field will serve as a counter for each change that is made via palette.
     // It will be appended to the stylesheet call to allow browsers to cache stylesheets while being sure
@@ -118,18 +121,15 @@ module.exports = {
       {
         name: 'palette',
         label: 'Palette Fields',
-        fields: fieldNames.concat([ 'paletteCounter' ])
+        fields: fieldNames.concat(['paletteCounter'])
       }
     ]);
 
-    // This route serves the existing palette stylesheet, constructed from the global object
-    // We do it this way so the browser can cache the styles as often as possible
-    self.route('get', 'palette-styles', function (req, res) {
-
+    self.buildCssFromOptions = function (req, callback) {
       var paletteFields = self.apos.modules['apostrophe-global'].options.paletteFields;
       var rules = [];
 
-      paletteFields.forEach(function(field) {
+      paletteFields.forEach(function (field) {
         var selectors = field.selector;
         var properties = field.property;
         var fieldValue = req.data.global[field.name];
@@ -140,11 +140,11 @@ module.exports = {
         }
 
         if (_.isString(selectors)) {
-          selectors = [ selectors ];
+          selectors = [selectors];
         }
 
         if (_.isString(properties)) {
-          properties = [ properties ];
+          properties = [properties];
         }
 
         properties.forEach(function (property) {
@@ -168,15 +168,86 @@ module.exports = {
         });
       });
 
+      callback(null, rules.join(''));
+    }
+
+    self.buildCssFromLess = function (req, callback) {
+      var paletteFields = self.apos.modules['apostrophe-global'].options.paletteFields;
+      var vars = {};
+
+      paletteFields.forEach(function (field) {
+        var fieldValue = req.data.global[field.name];
+        var fieldUnit = field.unit || '';
+
+        if (fieldValue) {
+          vars[field.name] = fieldValue + fieldUnit;
+        }
+      });
+
+      less.render(self.paletteLess, {
+        modifyVars: vars,
+        compress: true,
+        paths: self.paletteLessPaths
+      }, function (err, result) {
+        if (err) {
+          return callback(err);
+        }
+
+        callback(null, result.css);
+      });
+    }
+
+    if (options.less) {
+      self.paletteLessFile = options.paletteLessFile || (self.apos.rootDir + '/lib/modules/apostrophe-palette-global/styles/index.less');
+      self.paletteLessPaths = options.paletteLessPaths || [path.dirname(self.paletteLessFile)];
+
+      self.buildCss = self.buildCssFromLess;
+    } else {
+      self.buildCss = self.buildCssFromOptions;
+    }
+
+    self.watchPaletteEvents = function () {
+      self.apos.on('palette-updated', function () {
+        // Clear cached CSS
+        self.paletteCss = null;
+      });
+    }
+
+    // This route serves the existing palette stylesheet, constructed from the global object
+    // We do it this way so the browser can cache the styles as often as possible
+    self.route('get', 'palette-styles', function (req, res) {
       res.setHeader('Content-Type', 'text/css');
       res.setHeader('Cache-Control', 'public, max-age=31557600');
-      return res.send(rules.join(''));
+
+      // Send cached CSS for better performance
+      if (self.paletteCss) {
+        return res.send(self.paletteCss);
+      }
+
+      self.buildCss(req, function (err, css) {
+        if (err) {
+          self.apos.utils.error(err);
+        }
+
+        self.paletteCss = css;
+
+        return res.send(css);
+      });
 
     });
   },
 
   // Add a Open/Close button to the admin bar
-  afterConstruct: function(self) {
+  afterConstruct: function (self) {
     self.apos.adminBar.add('apostrophe-palette', 'Open Palette');
+
+    if (self.paletteLessFile) {
+      self.paletteLess = fs.readFileSync(self.paletteLessFile, 'utf8');
+    }
+
+    // CSS will be compiled on first request and cached here
+    self.paletteCss = null;
+
+    self.watchPaletteEvents();
   }
 };

--- a/lib/modules/apostrophe-palette-global/index.js
+++ b/lib/modules/apostrophe-palette-global/index.js
@@ -48,7 +48,6 @@ module.exports = {
             if (pField) {
               temp.schema.push(pField);
             } else {
-              console.log(123, field);
               self.apos.utils.warn('Unrecognized field in arrangePaletteFields: ' + field);
             }
           });

--- a/lib/modules/apostrophe-palette-widgets/index.js
+++ b/lib/modules/apostrophe-palette-widgets/index.js
@@ -8,7 +8,7 @@ module.exports = {
   beforeConstruct: function (self, options) { },
   afterConstruct: function (self) {
     self.pushAsset('stylesheet', 'index', { when: 'user' });
-    self.pushAsset('script', 'leanUser', { when: 'lean' });
+    // self.pushAsset('script', 'leanUser', { when: 'lean' });
   },
 
   construct: function (self, options) {
@@ -66,6 +66,9 @@ module.exports = {
         if (err) {
           self.apos.utils.error(err);
         }
+
+        self.apos.emit('palette-updated');
+
         return res.send({ status: err ? 'error' : 'ok' });
       });
     });
@@ -84,6 +87,7 @@ module.exports = {
         browserOptions.piece[field.name] = req.data.global[field.name];
       }
       browserOptions.piece._id = req.data.global._id;
+      browserOptions.less = !!self.apos.docs.getManager('apostrophe-global').paletteLess;
       return browserOptions;
     };
   }

--- a/lib/modules/apostrophe-palette-widgets/index.js
+++ b/lib/modules/apostrophe-palette-widgets/index.js
@@ -8,7 +8,7 @@ module.exports = {
   beforeConstruct: function (self, options) { },
   afterConstruct: function (self) {
     self.pushAsset('stylesheet', 'index', { when: 'user' });
-    // self.pushAsset('script', 'leanUser', { when: 'lean' });
+    self.pushAsset('script', 'leanUser', { when: 'lean' });
   },
 
   construct: function (self, options) {

--- a/lib/modules/apostrophe-palette-widgets/public/js/leanUser.js
+++ b/lib/modules/apostrophe-palette-widgets/public/js/leanUser.js
@@ -126,11 +126,9 @@
   // Reload CSS file
   function reloadCss() {
     var $link = $('[data-apos-palette-link]');
-    var parts = $link.attr('href').split('?v=');
-    var url = parts[0];
-    var version = ++parts[1];
+    var url = $link.attr('href').split('?v=')[0];
 
-    $link.attr('href', url + '?v=' + version);
+    $link.attr('href', url + '?v=' + Date.now());
   }
 
   function save($field, fieldValue, fieldSchema, $tag, less) {

--- a/lib/modules/apostrophe-palette-widgets/public/js/leanUser.js
+++ b/lib/modules/apostrophe-palette-widgets/public/js/leanUser.js
@@ -1,18 +1,19 @@
 // Make sure jquery exists before proceeding, this
 // code is really for logged in editors only
 
-(function() {
+(function () {
   if (window.$) {
     apos.paletteWidgets = {};
-    apos.utils.widgetPlayers['apostrophe-palette'] = function(el, data, options) {
+    apos.utils.widgetPlayers['apostrophe-palette'] = function (el, data, options) {
       var $form = $('[data-apos-palette-form]');
       var $tag = $('[data-apos-palette-styles]');
       var schema = apos.modules['apostrophe-palette-widgets'].options.schema;
+      var less = apos.modules['apostrophe-palette-widgets'].options.less;
       var piece = _.cloneDeep(apos.modules['apostrophe-palette-widgets'].options.piece);
-      init($form, $tag, schema, piece);
+      init($form, $tag, schema, piece, less);
 
       // apostrophe-palette interface
-      $form.on('click', '[data-apos-palette-group-button]', function(e) {
+      $form.on('click', '[data-apos-palette-group-button]', function (e) {
         e.preventDefault();
         var activeClass = 'apos-palette__group--active';
         var $this = $(this);
@@ -22,7 +23,7 @@
           return;
         }
 
-        $this.parent().siblings('.apos-palette__group').each(function() {
+        $this.parent().siblings('.apos-palette__group').each(function () {
           var $self = $(this);
           $self.removeClass(activeClass);
           $self.find('.apos-palette__group').removeClass(activeClass);
@@ -40,7 +41,7 @@
     apos.paletteWidgets.debouncedSaves = {};
   }
 
-  function init($form, $tag, schema, piece) {
+  function init($form, $tag, schema, piece, less) {
     return apos.schemas.populate($form, schema, piece, function (err) {
       if (err) {
         apos.notify('A problem populating/enhancing the palette field', {
@@ -50,13 +51,13 @@
         return;
       }
 
-      listen($form, $tag, schema, piece);
+      listen($form, $tag, schema, piece, less);
 
     });
   };
 
   // Listen for changes to form elements within the palette tool
-  function listen($form, $tag, schema, piece) {
+  function listen($form, $tag, schema, piece, less) {
     $form.find(':input:not([data-apos-workflow-field-state-control])').change(function () {
       var $field = $(this).parents('[data-apos-palette-field]');
       var fieldValue = $field.find(':input:not([data-apos-workflow-field-state-control])').val();
@@ -65,14 +66,16 @@
           return field;
         }
       });
-      submit($field, fieldValue, fieldSchema, $tag);
+      submit($field, fieldValue, fieldSchema, $tag, less);
     });
   };
 
   // Handles prepping the current front end for changes as well as sending
   // updates to the apostrophe-global piece
-  function submit ($field, fieldValue, fieldSchema, $tag) {
-    apply($field, fieldValue, fieldSchema, $tag);
+  function submit($field, fieldValue, fieldSchema, $tag, less) {
+    if (!less) {
+      apply($field, fieldValue, fieldSchema, $tag);
+    }
     var saveField = apos.paletteWidgets.debouncedSaves[fieldSchema.name];
     if (!saveField) {
       saveField = _.debounce(save, 250, {
@@ -81,11 +84,11 @@
       });
       apos.paletteWidgets.debouncedSaves[fieldSchema.name] = saveField;
     }
-    saveField($field, fieldValue, fieldSchema, $tag);
+    saveField($field, fieldValue, fieldSchema, $tag, less);
   };
 
   // Append new CSS rule to the end of our generated stylesheet. Last rule wins!
-  function apply ($field, fieldValue, fieldSchema, $tag) {
+  function apply($field, fieldValue, fieldSchema, $tag) {
     var selector = $field.attr('data-apos-palette-selector');
     var property = $field.attr('data-apos-palette-property');
     var mediaQuery = $field.attr('data-apos-palette-media-query');
@@ -120,7 +123,17 @@
     }
   };
 
-  function save ($field, fieldValue, fieldSchema, $tag) {
+  // Reload CSS file
+  function reloadCss() {
+    var $link = $('[data-apos-palette-link]');
+    var parts = $link.attr('href').split('?v=');
+    var url = parts[0];
+    var version = ++parts[1];
+
+    $link.attr('href', url + '?v=' + version);
+  }
+
+  function save($field, fieldValue, fieldSchema, $tag, less) {
     // build an object of data from the palette field to update the apostrophe-global piece with
     var save = {};
     save.field = {
@@ -129,17 +142,21 @@
     };
     save._id = apos.modules['apostrophe-palette-widgets'].options.piece._id;
 
-    return send(function(err) {
+    return send(function (err) {
       if (err) {
         apos.notify('Something was not right. Please review your submission.', {
           type: 'error',
           dismiss: true
         });
       }
+
+      if (less) {
+        reloadCss();
+      }
     });
 
     // send the update back to the server
-    function send (callback) {
+    function send(callback) {
       apos.utils.post('/modules/apostrophe-palette-widgets/palette-update', save, function (err, res) {
         if (err) {
           return callback('error');

--- a/lib/modules/apostrophe-palette-widgets/public/js/user.js
+++ b/lib/modules/apostrophe-palette-widgets/public/js/user.js
@@ -8,13 +8,13 @@ apos.define('apostrophe-palette-widgets', {
     self.afterSubmit = function ($field, fieldValue, fieldSchema) {};
 
     self.play = function ($widget, data, options) {
-
       var $form = $('[data-apos-palette-form]');
       var $tag = $('[data-apos-palette-styles]');
       var schema = self.options.schema;
+      var less = self.options.less;
       var piece = _.cloneDeep(self.options.piece);
 
-      self.init($form, $tag, schema, piece);
+      self.init($form, $tag, schema, piece, less);
 
       // apostrophe-palette interface
       $form.on('click', '[data-apos-palette-group-button]', function(e) {
@@ -37,7 +37,7 @@ apos.define('apostrophe-palette-widgets', {
       });
     };
 
-    self.init = function ($form, $tag, schema, piece) {
+    self.init = function ($form, $tag, schema, piece, less) {
       return apos.schemas.populate($form, schema, piece, function (err) {
         if (err) {
           apos.notify('A problem populating/enhancing the palette field', {
@@ -47,13 +47,13 @@ apos.define('apostrophe-palette-widgets', {
           return;
         }
 
-        self.listen($form, $tag, schema, piece);
+        self.listen($form, $tag, schema, piece, less);
 
       });
     };
 
     // Listen for changes to form elements within the palette tool
-    self.listen = function ($form, $tag, schema, piece) {
+    self.listen = function ($form, $tag, schema, piece, less) {
       $form.find(':input:not([data-apos-workflow-field-state-control])').change(function () {
         var $field = $(this).parents('[data-apos-palette-field]');
         var fieldValue = $field.find(':input:not([data-apos-workflow-field-state-control])').val();
@@ -62,7 +62,7 @@ apos.define('apostrophe-palette-widgets', {
             return field;
           }
         });
-        self.submit($field, fieldValue, fieldSchema, $tag);
+        self.submit($field, fieldValue, fieldSchema, $tag, less);
       });
     };
 
@@ -74,8 +74,10 @@ apos.define('apostrophe-palette-widgets', {
 
     // Handles prepping the current front end for changes as well as sending
     // updates to the apostrophe-global piece
-    self.submit = function ($field, fieldValue, fieldSchema, $tag) {
-      self.apply($field, fieldValue, fieldSchema, $tag);
+    self.submit = function ($field, fieldValue, fieldSchema, $tag, less) {
+      if (!less) {
+        self.apply($field, fieldValue, fieldSchema, $tag);
+      }
       var save = self.debouncedSaves[fieldSchema.name];
       if (!save) {
         save = _.debounce(self.save, 250, {
@@ -84,7 +86,7 @@ apos.define('apostrophe-palette-widgets', {
         });
         self.debouncedSaves[fieldSchema.name] = save;
       }
-      save($field, fieldValue, fieldSchema, $tag);
+      save($field, fieldValue, fieldSchema, $tag, less);
     };
 
     // Append new CSS rule to the end of our generated stylesheet. Last rule wins!
@@ -123,7 +125,17 @@ apos.define('apostrophe-palette-widgets', {
       }
     };
 
-    self.save = function($field, fieldValue, fieldSchema, $tag) {
+    // Reload CSS file
+    self.reloadCss = function() {
+      var $link = $('[data-apos-palette-link]');
+      var parts = $link.attr('href').split('?v=');
+      var url = parts[0];
+      var version = ++parts[1];
+  
+      $link.attr('href', url + '?v=' + version);
+    }
+
+    self.save = function($field, fieldValue, fieldSchema, $tag, less) {
       // build an object of data from the palette field to update the apostrophe-global piece with
       var save = {};
       save.field = {
@@ -139,6 +151,10 @@ apos.define('apostrophe-palette-widgets', {
             dismiss: true
           });
         } else {
+          if (less) {
+            self.reloadCss();
+          }
+
           self.afterSubmit($field, fieldValue, fieldSchema, $tag);
         }
       });

--- a/lib/modules/apostrophe-palette-widgets/public/js/user.js
+++ b/lib/modules/apostrophe-palette-widgets/public/js/user.js
@@ -128,11 +128,9 @@ apos.define('apostrophe-palette-widgets', {
     // Reload CSS file
     self.reloadCss = function() {
       var $link = $('[data-apos-palette-link]');
-      var parts = $link.attr('href').split('?v=');
-      var url = parts[0];
-      var version = ++parts[1];
-  
-      $link.attr('href', url + '?v=' + version);
+      var url = $link.attr('href').split('?v=')[0];
+
+      $link.attr('href', url + '?v=' + Date.now());
     }
 
     self.save = function($field, fieldValue, fieldSchema, $tag, less) {

--- a/lib/modules/apostrophe-palette-widgets/views/macros.html
+++ b/lib/modules/apostrophe-palette-widgets/views/macros.html
@@ -11,7 +11,7 @@
 {% endmacro %}
 
 {% macro stylesheetLink(global) %}
-  <link rel="stylesheet" href="/modules/apostrophe-global/palette-styles?v={{ global.paletteCounter or 'e' }}">
+  <link rel="stylesheet" data-apos-palette-link href="/modules/apostrophe-global/palette-styles?v={{ global.paletteCounter or 'e' }}">
 {% endmacro %}
 
 {% macro stylesheetTag() %}


### PR DESCRIPTION
Added possibility to build CSS from LESS files.

You can use this by adding LESS code into: `lib/modules/apostrophe-palette-global/styles/index.less`

```less
@import "other-less-file";

// default value will be changed from palette fields
@color-background: #ff3f00;

body {
  background-color: @color-background;
}
```

Configure `apostrophe-palette-global` module in `app.js` or `lib/modules/apostrophe-palette-global/index.js`:
```js
...
'apostrophe-palette-global': {
    less: true, // Using LESS files

    paletteFields: [ // array of fields, like a normal schema
        {
            name: 'color-background',
            label: 'Background color',
            type: 'color',
        }
    ]
}
...
```