### PR TITLE
Allow saving of falsey values except null

### DIFF
--- a/lib/modules/apostrophe-palette-global/index.js
+++ b/lib/modules/apostrophe-palette-global/index.js
@@ -135,7 +135,7 @@ module.exports = {
         var fieldValue = req.data.global[field.name];
         var fieldUnit = field.unit || '';
 
-        if (!fieldValue) {
+        if (fieldValue == null) {
           return;
         }
 


### PR DESCRIPTION
Previously couldn't save a palette value of 0 (like 0 border width) since it was falsey.